### PR TITLE
Unsubscribed users no longer see movement in home

### DIFF
--- a/web/gridt/resources/movements.py
+++ b/web/gridt/resources/movements.py
@@ -52,8 +52,8 @@ class MovementsResource(Resource):
 class SubscriptionsResource(Resource):
     @jwt_required()
     def get(self):
-        movements = set(current_identity.movements)
-        movement_dicts = [movement.dictify(current_identity) for movement in movements]
+        current_movements = set(current_identity.current_movements)
+        movement_dicts = [movement.dictify(current_identity) for movement in current_movements]
         return movement_dicts, 200
 
 

--- a/web/gridt/tests/integration/resources/test_movements.py
+++ b/web/gridt/tests/integration/resources/test_movements.py
@@ -505,3 +505,22 @@ class SubscriptionsResourceTest(BaseTest):
             data = json.loads(resp.data)
             self.maxDiff = None
             self.assertEqual(data, expected)
+
+    def test_unsubscribe_get_subscriptions(self):
+        with self.app_context():
+            self.create_movement()
+            self.create_user_in_movement(self.movements[0])
+
+            resp_delete = self.request_as_user(
+                self.users[0], "DELETE", "/movements/1/subscriber"
+            )
+
+            self.assertEqual(resp_delete.status_code, 200)
+
+            resp = self.request_as_user(
+                self.users[0], "GET", "/movements/subscriptions"
+            )
+            data = json.loads(resp.data)
+
+            self.assertEqual(resp.status_code, 200)
+            self.assertEqual(data, [])


### PR DESCRIPTION
Should solve issue #61 

* /movements/subscriptions now only shows current movements.
* Wrote a test for this problem as well.