### PR TITLE
Resource tests use helper functions

### DIFF
--- a/web/gridt/resources/leader.py
+++ b/web/gridt/resources/leader.py
@@ -53,7 +53,7 @@ class LeaderResource(Resource):
         new_leader = movement.swap_leader(current_identity, leader)
 
         if not new_leader:
-            return {"message": "Could not find leader to replace the current one."}
+            return {"message": "Could not find leader to replace the current one."}, 400
 
         time_stamp = None
         if Signal.find_last(new_leader, movement):

--- a/web/gridt/tests/integration/resources/test_leader.py
+++ b/web/gridt/tests/integration/resources/test_leader.py
@@ -14,25 +14,23 @@ class SwapTest(BaseTest):
     def test_swap_leader_correctly(self):
         with self.app_context():
             movement = self.create_movement()
-            user1 = self.create_user_in_movement(movement)
-            user2 = self.create_user_in_movement(movement)
-            user3 = self.create_user_in_movement(movement)
-            user4 = self.create_user_in_movement(movement)
-            user5 = self.create_user_in_movement(movement)
+            # Create six users, the first five of which
+            # all follow each other. The sixth has no followers.
+            for user in range(5):
+                self.create_user_in_movement(movement)
             user6 = self.create_user_in_movement(movement)
 
             signal = self.signal_as_user(self.users[0], self.movements[0])
-            
+
             expected = user6.dictify()
             expected["last_signal"] = None
 
+            # Test that the fifth user can be replaced
+            # with the sixth user.
             resp = self.request_as_user(
-                self.users[0],
-                "POST",
-                f"/movements/{movement.id}/leader/5",
-                json={}
+                self.users[0], "POST", f"/movements/{movement.id}/leader/5", json={}
             )
-            
+
             self.assertEqual(resp.status_code, 200)
             self.assertEqual(resp.get_json(), expected)
 
@@ -46,26 +44,20 @@ class SwapTest(BaseTest):
             time_stamp = signal.time_stamp
 
             resp = self.request_as_user(
-                self.users[0],
-                "POST",
-                f"/movements/{movement.id}/leader/2",
-                json={}
+                self.users[0], "POST", f"/movements/{movement.id}/leader/2", json={}
             )
-            
+
             self.assertEqual(resp.status_code, 400)
             self.assertEqual(
-                resp.get_json(), {"message": "Could not find leader to replace the current one."}
+                resp.get_json(),
+                {"message": "Could not find leader to replace the current one."},
             )
 
     def test_swap_leader_movement_nonexistant(self):
         with self.app_context():
             user = self.create_user()
-            
-            resp = self.request_as_user(
-                self.users[0],
-                "POST",
-                "/movements/1/leader/2"
-            )
+
+            resp = self.request_as_user(self.users[0], "POST", "/movements/1/leader/2")
 
             self.assertEqual(resp.status_code, 404)
             self.assertEqual(
@@ -77,11 +69,7 @@ class SwapTest(BaseTest):
             movement = self.create_movement()
             user = self.create_user()
 
-            resp = self.request_as_user(
-                self.users[0],
-                "POST",
-                "/movements/1/leader/2"
-            )
+            resp = self.request_as_user(self.users[0], "POST", "/movements/1/leader/2")
 
             self.assertEqual(resp.status_code, 400)
             self.assertEqual(
@@ -95,11 +83,7 @@ class SwapTest(BaseTest):
             user1 = self.create_user_in_movement(movement)
             user2 = self.create_user()
 
-            resp = self.request_as_user(
-                self.users[0],
-                "POST",
-                "/movements/1/leader/2"
-            )
+            resp = self.request_as_user(self.users[0], "POST", "/movements/1/leader/2")
 
             self.assertEqual(resp.status_code, 400)
             self.assertEqual(

--- a/web/gridt/tests/integration/resources/test_leader.py
+++ b/web/gridt/tests/integration/resources/test_leader.py
@@ -52,9 +52,7 @@ class SwapTest(BaseTest):
                 json={}
             )
             
-            # As it stands, a failed leader search will yield a 200.
-            # Should it be that way? I would personally expect a 400.
-            self.assertEqual(resp.status_code, 200)
+            self.assertEqual(resp.status_code, 400)
             self.assertEqual(
                 resp.get_json(), {"message": "Could not find leader to replace the current one."}
             )

--- a/web/gridt/tests/integration/resources/test_movements.py
+++ b/web/gridt/tests/integration/resources/test_movements.py
@@ -34,18 +34,16 @@ class MovementsTest(BaseTest):
 
             movement3.add_user(user1)
             movement3.add_user(user2)
-            signal3 = self.signal_as_user(self.users[0], movement3, message="test message")
+            signal3 = self.signal_as_user(
+                self.users[0], movement3, message="test message"
+            )
 
             # To prevent sqlalchemy.orm.exc.DetachedInstanceError
             stamp2 = str(signal2.time_stamp.astimezone())
             stamp3 = str(signal3.time_stamp.astimezone())
 
             # Check that the response matches expectation
-            resp = self.request_as_user(
-                self.users[1],
-                "GET",
-                "/movements",
-            )
+            resp = self.request_as_user(self.users[1], "GET", "/movements",)
 
             expected = [
                 {
@@ -232,15 +230,9 @@ class MovementsTest(BaseTest):
             movement = self.create_movement()
 
             resp1 = self.request_as_user(
-                self.users[0],
-                "GET"
-                f"/movements/{movement.name}"
+                self.users[0], "GET", f"/movements/{movement.name}",
             )
-            resp2 = self.request_as_user(
-                self.users[0],
-                "GET",
-                "/movements/1"
-            )
+            resp2 = self.request_as_user(self.users[0], "GET", "/movements/1",)
             expected = {
                 "id": 1,
                 "name": movement.name,
@@ -258,16 +250,8 @@ class MovementsTest(BaseTest):
         with self.app_context():
             user = self.create_user()
 
-            resp1 = self.request_as_user(
-                self.users[0],
-                "GET",
-                "/movements/Flossing",
-            )
-            resp2 = self.request_as_user(
-                self.users[0],
-                "GET",
-                "/movements/1",
-            )
+            resp1 = self.request_as_user(self.users[0], "GET", "/movements/Flossing",)
+            resp2 = self.request_as_user(self.users[0], "GET", "/movements/1",)
 
             self.assertEqual(resp1.status_code, 404)
             self.assertEqual(resp2.status_code, 404)
@@ -287,9 +271,7 @@ class SubscribeTest(BaseTest):
             user = self.create_user()
 
             resp = self.request_as_user(
-                self.users[0],
-                "PUT",
-                "/movements/1/subscriber",
+                self.users[0], "PUT", "/movements/1/subscriber",
             )
 
         # Using self.client will call db.session.commit(), this will close the
@@ -309,9 +291,7 @@ class SubscribeTest(BaseTest):
 
             # Do it twice, should not change anything.
             resp = self.request_as_user(
-                self.users[0],
-                "PUT",
-                "/movements/1/subscriber",
+                self.users[0], "PUT", "/movements/1/subscriber",
             )
             self.assertEqual(resp.status_code, 200)
             self.assertEqual(
@@ -327,9 +307,7 @@ class SubscribeTest(BaseTest):
             user = self.create_user()
 
             resp = self.request_as_user(
-                self.users[0],
-                "PUT",
-                "/movements/Flossing/subscriber",
+                self.users[0], "PUT", "/movements/Flossing/subscriber",
             )
             self.assertEqual(resp.status_code, 404)
             self.assertEqual(
@@ -380,9 +358,7 @@ class SubscribeTest(BaseTest):
             user = self.create_user()
 
             resp = self.request_as_user(
-                self.users[0],
-                "DELETE",
-                "/movements/Flossing/subscriber",
+                self.users[0], "DELETE", "/movements/Flossing/subscriber",
             )
             self.assertEqual(resp.status_code, 404)
             self.assertEqual(
@@ -395,12 +371,10 @@ class NewSignalTest(BaseTest):
     def test_create_new_signal(self, func):
         with self.app_context():
             movement = self.create_movement()
-            user = self.create_user_in_movement()
+            user = self.create_user_in_movement(movement)
 
             resp = self.request_as_user(
-                self.users[0],
-                "POST",
-                f"/movements/{movement.name}/signal",
+                self.users[0], "POST", f"/movements/{movement.name}/signal",
             )
 
             self.assertEqual(
@@ -418,11 +392,9 @@ class NewSignalTest(BaseTest):
     def test_movement_nonexistant(self):
         with self.app_context():
             user = self.create_user()
-            
+
             resp = self.request_as_user(
-                self.users[0],
-                "POST",
-                "/movements/Flossing/signal",
+                self.users[0], "POST", "/movements/Flossing/signal",
             )
 
             self.assertEqual(resp.status_code, 404)
@@ -435,11 +407,7 @@ class NewSignalTest(BaseTest):
             movement = self.create_movement()
             user = self.create_user()
 
-            resp = self.request_as_user(
-                self.users[0],
-                "POST",
-                "/movements/Flossing/signal",
-            )
+            resp = self.request_as_user(self.users[0], "POST", "/movements/1/signal",)
 
             self.assertEqual(resp.status_code, 400)
             self.assertEqual(


### PR DESCRIPTION
fixes #77 
- Cleaned up the code for resource tests with helper functions in base_test.py
- Didn't touch movements post tests, that would create a merge confict with #80 
- Extra: lets leader resource return 400 if no possible leaders are found for swap_leader.
